### PR TITLE
Fix build and add support for CI to release two variant without pack

### DIFF
--- a/.github/workflows/CI - Build.yml
+++ b/.github/workflows/CI - Build.yml
@@ -36,41 +36,31 @@ jobs:
 
       - name: Restore
         working-directory: VRChatAutoFishing
-        run: dotnet restore "VRChatAutoFishing.csproj"
+        run: dotnet restore -r ${{ matrix.rid }} "VRChatAutoFishing.csproj"
 
-      - name: Build
-        working-directory: VRChatAutoFishing
-        run: dotnet build "VRChatAutoFishing.csproj" --configuration Release --no-restore
-
-      - name: Publish single-file self-contained
+      - name: Publish
         working-directory: VRChatAutoFishing
         run: |
-          dotnet publish "VRChatAutoFishing.csproj" -c Release -r ${{ matrix.rid }} --self-contained false -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false -o ./publish
+          dotnet publish "VRChatAutoFishing.csproj" -c Release  -p:DebugType=None -p:DebugSymbols=false -o ./publish --no-restore
+          dotnet publish "VRChatAutoFishing.csproj" -c ReleaseWithRuntime  -p:DebugType=None -p:DebugSymbols=false -o ./publish --no-restore
 
-      - name: Package artifact
-        working-directory: VRChatAutoFishing
-        shell: pwsh
-        run: |
-          Write-Host 'Checking publish output...'
-          if (-not (Test-Path -Path ./publish)) {
-            Write-Host 'Publish directory not found. Listing repository:'
-            Get-ChildItem -Force -Recurse | Select-Object -First 100
-            exit 1
-          }
-          $exe = Get-ChildItem -Path ./publish -Recurse -Filter '*.exe' | Select-Object -First 1
-          if (-not $exe) {
-            Write-Host 'No exe found in publish directory. Contents of publish:'
-            Get-ChildItem -Path ./publish -Recurse -Force | Select-Object -First 200
-            exit 1
-          }
-          $dest = Join-Path $env:GITHUB_WORKSPACE ('release-' + "${{ matrix.name }}" + '.zip')
-          Write-Host "Compressing executable $($exe.FullName) to $dest"
-          Compress-Archive -Path $exe.FullName -DestinationPath $dest -Force
-
-      - name: Upload Build Artifact
+      - name: Upload Build Artifact - Non-Runtime
         uses: actions/upload-artifact@v4
         with:
           name: release-${{ matrix.name }}
-          path: ${{ github.workspace }}/release-${{ matrix.name }}.zip
+          path: ${{ github.workspace }}/VRChatAutoFishing/publish/VRChatAutoFishing.exe
 
-  # release job removed: workflow now only builds and uploads artifacts
+      - name: Upload Build Artifact - With-Runtime
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.name }}-with-runtime
+          path: ${{ github.workspace }}/VRChatAutoFishing/publish/VRChatAutoFishingOneClick.exe
+      
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: github.ref_type == 'tag'
+        with:
+          files: |
+            ${{ github.workspace }}/VRChatAutoFishing/publish/VRChatAutoFishing.exe
+            ${{ github.workspace }}/VRChatAutoFishing/publish/VRChatAutoFishingOneClick.exe
+

--- a/VRChatAutoFishing.sln
+++ b/VRChatAutoFishing.sln
@@ -9,12 +9,15 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		ReleaseWithRuntime|Any CPU = ReleaseWithRuntime|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D11B0F8F-C1A3-4779-95ED-D6C76B5E0758}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D11B0F8F-C1A3-4779-95ED-D6C76B5E0758}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D11B0F8F-C1A3-4779-95ED-D6C76B5E0758}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D11B0F8F-C1A3-4779-95ED-D6C76B5E0758}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D11B0F8F-C1A3-4779-95ED-D6C76B5E0758}.ReleaseWithRuntime|Any CPU.ActiveCfg = ReleaseWithRuntime|Any CPU
+		{D11B0F8F-C1A3-4779-95ED-D6C76B5E0758}.ReleaseWithRuntime|Any CPU.Build.0 = ReleaseWithRuntime|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/VRChatAutoFishing/MainForm.cs
+++ b/VRChatAutoFishing/MainForm.cs
@@ -19,6 +19,8 @@ namespace VRChatAutoFishing
             kReeling,
             kFinishedReel,
             kStopped,
+            kReCasting,
+            kReReeling,
             // Exceptions
             kTimeoutReelSingle,
             kTimeoutReel,
@@ -232,6 +234,8 @@ namespace VRChatAutoFishing
                 ActionState.kReeling => "收杆中",
                 ActionState.kFinishedReel => "收杆完成",
                 ActionState.kStopped => "已停止",
+                ActionState.kReCasting => "重新抛竿",
+                ActionState.kReReeling => "重新收杆",
 
                 ActionState.kTimeoutReelSingle => "收杆超时(单次)",
                 ActionState.kTimeoutReel => "收杆超时",
@@ -427,7 +431,7 @@ namespace VRChatAutoFishing
                 _isProtected = true;
 
                 // 第一步：抛竿2秒确保线收到位
-                _currentAction = "重钓抛竿";
+                _currentAction = ActionState.kReCasting;
                 UpdateStatusText(_currentAction);
                 SendClick(true);
 
@@ -443,7 +447,7 @@ namespace VRChatAutoFishing
                 SendClick(false);
 
                 // 第二步：收杆20秒确保线完全收回
-                _currentAction = "重钓收杆";
+                _currentAction = ActionState.kReReeling;
                 UpdateStatusText(_currentAction);
                 SendClick(true);
 
@@ -459,25 +463,6 @@ namespace VRChatAutoFishing
                 SendClick(false);
 
                 // 第三步：重新开始钓鱼流程
-                if (!_isClosing)
-                {
-                    PerformCast();
-                }
-            }
-            finally
-            {
-                _isProtected = false;
-            }
-        }
-
-        private void ForceReel()
-        {
-            if (_isProtected || _isClosing) return;
-
-            try
-            {
-                _isProtected = true;
-                PerformReel();
                 if (!_isClosing)
                 {
                     PerformCast();
@@ -559,7 +544,7 @@ namespace VRChatAutoFishing
                 else
                 {
                     _currentAction = ActionState.kTimeoutReel;
-                    _notificationManager.NotifyAll("收杆超时，未检测到SAVED DATA事件！请检查游戏状态。");
+                    _notificationManager.NotifyAll("收杆超时，未检测到SAVED DATA事件！如果此事件持续，请检查游戏状态。");
                 }
                 _showingFishCount = false;
                 UpdateStatusText(_currentAction);

--- a/VRChatAutoFishing/VRChatAutoFishing.csproj
+++ b/VRChatAutoFishing/VRChatAutoFishing.csproj
@@ -6,8 +6,6 @@
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
-
-    <ApplicationIcon>app.ico</ApplicationIcon>
     <AssemblyTitle>VRChat自动钓鱼工具</AssemblyTitle>
     <AssemblyDescription>合法的游戏辅助工具</AssemblyDescription>
     <AssemblyCompany>个人开发</AssemblyCompany>
@@ -15,18 +13,28 @@
     <AssemblyCopyright>Copyright © arcxingye 2024</AssemblyCopyright>
     <AssemblyVersion>1.5.0.0</AssemblyVersion>
     <FileVersion>1.5.0.0</FileVersion>
-
-    <PublishSingleFile>true</PublishSingleFile>
-    <SelfContained>true</SelfContained>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <PublishReadyToRun>true</PublishReadyToRun>
+    <Configurations>Debug;Release;ReleaseWithRuntime</Configurations>
+    <ApplicationIcon>app.ico</ApplicationIcon>
+	 <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Content Include="app.ico">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+  <!-- 配置带 Runtime 的版本 -->
+  <PropertyGroup Condition="'$(Configuration)' == 'ReleaseWithRuntime'">
+	<AssemblyName>VRChatAutoFishingOneClick</AssemblyName>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained> <!-- 包含 .NET Runtime -->
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    
+	<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+  </PropertyGroup>
+
+  <!-- 配置不带 Runtime 的版本 -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>false</SelfContained> <!-- 不包含 .NET Runtime -->
+	<AssemblyName>VRChatAutoFishing</AssemblyName>
+  </PropertyGroup>
+
   
   <ItemGroup>
     <None Remove="Resources\help_image1.png" />


### PR DESCRIPTION
修复了上次合入后currentState类型不兼容过的问题；
调好了CI构建和发布；构建可以在主分支上运行，发布仅在tag上v*上进行。
默认发布两个版本，一个是无runtime的，另一个带runtime，后缀为OneClick。

参阅：
https://github.com/DynamicLoader/VRCAutoFisher/actions/runs/18994869977
https://github.com/DynamicLoader/VRCAutoFisher/releases/tag/v1.5.1

另外，你可能想要修一下版本号。